### PR TITLE
Fix importing banned_user.cfg with Steam3 [U:1:X]

### DIFF
--- a/web_upload/pages/admin.bans.php
+++ b/web_upload/pages/admin.bans.php
@@ -38,19 +38,26 @@ if(isset($_POST['action']) && $_POST['action'] == "importBans")
 					$GLOBALS['db']->Execute($pre, array("", $line[2], "Imported Ban", 0, 0, "banned_ip.cfg import", $_COOKIE['aid'], $_SERVER['REMOTE_ADDR'], 1));
 				}
 			} else { // if its an banned_user.cfg
-				if (!validate_steam($line[2]))
-					continue;
-				$check = $GLOBALS['db']->Execute("SELECT authid FROM `" . DB_PREFIX . "_bans` WHERE authid = ? AND RemoveType IS NULL", array($line[2]));
+				if (!validate_steam($line[2])) {
+					if (($accountId = getAccountId($line[2])) !== -1) {
+						$steam = renderSteam2($accountId, 0);
+					} else {
+						continue;
+					}
+				} else {
+					$steam = $line[2];
+				}
+				$check = $GLOBALS['db']->Execute("SELECT authid FROM `" . DB_PREFIX . "_bans` WHERE authid = ? AND RemoveType IS NULL", array($steam));
 
 				if($check->RecordCount() == 0)
 				{
-					if(!isset($_POST['friendsname']) || $_POST['friendsname'] != "on" || ($pname = GetCommunityName($line[2])) == "")
+					if(!isset($_POST['friendsname']) || $_POST['friendsname'] != "on" || ($pname = GetCommunityName($steam)) == "")
 						$pname = "Imported Ban";
 					
 					$bancnt++;
 					$pre = $GLOBALS['db']->Prepare("INSERT INTO ".DB_PREFIX."_bans(created,authid,ip,name,ends,length,reason,aid,adminIp,type) VALUES
 										(UNIX_TIMESTAMP(),?,?,?,(UNIX_TIMESTAMP() + ?),?,?,?,?,?)");
-					$GLOBALS['db']->Execute($pre, array($line[2], "", $pname, 0, 0, "banned_user.cfg import", $_COOKIE['aid'], $_SERVER['REMOTE_ADDR'], 0));
+					$GLOBALS['db']->Execute($pre, array($steam, "", $pname, 0, 0, "banned_user.cfg import", $_COOKIE['aid'], $_SERVER['REMOTE_ADDR'], 0));
 				}
 			}
 		}


### PR DESCRIPTION
As discussed on https://forums.alliedmods.net/showthread.php?t=264030, the Steam3 fixes doesn't yet allow import of banned_user.cfg's from TF2 with the Steam3 representation.

This PR fixes that, and confirmed to be working at the thread linked above.